### PR TITLE
ci: add PR validation workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+# Run on pull requests and pushes to main
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  validate:
+    name: Validate
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout the repository code
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Install Bun runtime
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      # Install project dependencies
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      # Run Biome checks (linting and formatting)
+      - name: Run Biome checks
+        run: bun run check
+
+      # Build the project to ensure it compiles
+      - name: Build
+        run: bun run build


### PR DESCRIPTION
This PR adds a CI workflow that validates pull requests before they can be merged to main. This prevents broken code from being released by semantic-release.

## Changes

- Added `.github/workflows/ci.yml` that runs on all PRs and pushes to main
- Workflow validates:
  - Biome linting and formatting checks (`bun run check`)
  - Successful project build (`bun run build`)

## Why?

Currently, semantic-release runs immediately when code is pushed to main without any validation. This means broken code (compilation errors, linting issues) could be automatically released.

## Next Steps

After merging this PR, we need to configure branch protection rules in the Org settings.