### PR TITLE
ci: add missing conventional-changelog-conventionalcommits dependency

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,7 @@
         "@types/bun": "latest",
         "@types/lodash": "^4.17.20",
         "commitizen": "^4.3.1",
+        "conventional-changelog-conventionalcommits": "^8.0.0",
         "cz-conventional-changelog": "^3.3.0",
         "lefthook": "^1.13.6",
         "semantic-release": "^25.0.2",
@@ -216,6 +217,8 @@
     "config-chain": ["config-chain@1.1.13", "", { "dependencies": { "ini": "^1.3.4", "proto-list": "~1.2.1" } }, "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ=="],
 
     "conventional-changelog-angular": ["conventional-changelog-angular@8.1.0", "", { "dependencies": { "compare-func": "^2.0.0" } }, "sha512-GGf2Nipn1RUCAktxuVauVr1e3r8QrLP/B0lEUsFktmGqc3ddbQkhoJZHJctVU829U1c6mTSWftrVOCHaL85Q3w=="],
+
+    "conventional-changelog-conventionalcommits": ["conventional-changelog-conventionalcommits@8.0.0", "", { "dependencies": { "compare-func": "^2.0.0" } }, "sha512-eOvlTO6OcySPyyyk8pKz2dP4jjElYunj9hn9/s0OB+gapTO8zwS9UQWrZ1pmF2hFs3vw1xhonOLGcGjy/zgsuA=="],
 
     "conventional-changelog-writer": ["conventional-changelog-writer@8.2.0", "", { "dependencies": { "conventional-commits-filter": "^5.0.0", "handlebars": "^4.7.7", "meow": "^13.0.0", "semver": "^7.5.2" }, "bin": { "conventional-changelog-writer": "dist/cli/index.js" } }, "sha512-Y2aW4596l9AEvFJRwFGJGiQjt2sBYTjPD18DdvxX9Vpz0Z7HQ+g1Z+6iYDAm1vR3QOJrDBkRHixHK/+FhkR6Pw=="],
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
 		"@types/bun": "latest",
 		"@types/lodash": "^4.17.20",
 		"commitizen": "^4.3.1",
+		"conventional-changelog-conventionalcommits": "^8.0.0",
 		"cz-conventional-changelog": "^3.3.0",
 		"lefthook": "^1.13.6",
 		"semantic-release": "^25.0.2"


### PR DESCRIPTION
Semantic-release needs conventional-changelog-conventionalcommits as a peer dependency