### PR TITLE
ci: prevent automatic major version bumps

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -17,7 +17,9 @@
 					{ "type": "style", "release": "patch" },
 					{ "type": "chore", "release": "patch" },
 					{ "type": "revert", "release": "patch" },
-					{ "type": "refactor", "release": "patch" }
+					{ "type": "refactor", "release": "patch" },
+
+					{ "breaking": true, "release": "minor" }
 				]
 			}
 		],


### PR DESCRIPTION
This PR configures semantic-release to treat breaking changes as minor version bumps instead of major, preventing automatic v1.0.0 releases until we're ready.