### PR TITLE
fix: update deprecated GitHub Actions to v4

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -49,7 +49,7 @@ jobs:
 
       # Cache Bun dependencies for faster builds
       - name: Cache Bun dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lockb') }}
@@ -103,7 +103,7 @@ jobs:
       # Upload as workflow artifacts for debugging
       - name: Upload workflow artifacts
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: debug-${{ matrix.platform }}
           path: dist/


### PR DESCRIPTION
This PR fixes workflow failures caused by deprecated GitHub Actions versions.

## Changes
- Updated `actions/cache` from v3 to v4
- Updated `actions/upload-artifact` from v3 to v4